### PR TITLE
removing dist-folder from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,4 +7,3 @@ test/
 src/
 bower.json
 webpack.config.js
-dist/


### PR DESCRIPTION
For our use case we need the compiled library from the dist-folder to include it into the angular app.