### PR TITLE
Use $validators instead of $parsers/$formatters

### DIFF
--- a/dist/ng-iban.js
+++ b/dist/ng-iban.js
@@ -74,11 +74,13 @@
 	        iban = parseIban(value);
 	        return IBAN.isValid(iban);
 	      };
+	      ctrl.$validators.ngIban = function (modelValue) {
+	        return isValidIban(modelValue);
+	      };
 	      ctrl.$parsers.unshift(function (viewValue) {
 	        var parsed, valid;
 	        if (viewValue != null) {
 	          valid = isValidIban(viewValue);
-	          ctrl.$setValidity('iban', valid);
 	          if (valid) {
 	            parsed = parseIban(viewValue);
 	            if (parsed !== viewValue) {
@@ -87,15 +89,14 @@
 	            }
 	            return parsed;
 	          } else {
-	            return void 0;
+	            return viewValue;
 	          }
 	        }
 	      });
-	      return ctrl.$formatters.unshift(function (modelValue) {
+	      ctrl.$formatters.unshift(function (modelValue) {
 	        var parsed, valid;
 	        if (modelValue != null) {
 	          valid = isValidIban(modelValue);
-	          ctrl.$setValidity('iban', valid);
 	          if (valid) {
 	            parsed = parseIban(modelValue);
 	            if (parsed !== modelValue) {

--- a/lib/ng-iban.js
+++ b/lib/ng-iban.js
@@ -22,11 +22,13 @@ angular.module('mm.iban', ['ng']).directive('ngIban', function() {
         iban = parseIban(value);
         return IBAN.isValid(iban);
       };
+      ctrl.$validators.ngIban = function(modelValue) {
+        return isValidIban(modelValue);
+      };
       ctrl.$parsers.unshift(function(viewValue) {
         var parsed, valid;
         if (viewValue != null) {
           valid = isValidIban(viewValue);
-          ctrl.$setValidity('iban', valid);
           if (valid) {
             parsed = parseIban(viewValue);
             if (parsed !== viewValue) {
@@ -35,15 +37,14 @@ angular.module('mm.iban', ['ng']).directive('ngIban', function() {
             }
             return parsed;
           } else {
-            return void 0;
+            return viewValue;
           }
         }
       });
-      return ctrl.$formatters.unshift(function(modelValue) {
+      ctrl.$formatters.unshift(function(modelValue) {
         var parsed, valid;
         if (modelValue != null) {
           valid = isValidIban(modelValue);
-          ctrl.$setValidity('iban', valid);
           if (valid) {
             parsed = parseIban(modelValue);
             if (parsed !== modelValue) {

--- a/src/ng-iban.coffee
+++ b/src/ng-iban.coffee
@@ -20,4 +20,26 @@ angular
       ctrl.$validators.ngIban = (modelValue) ->
         isValidIban modelValue
 
+      ctrl.$parsers.unshift (viewValue) ->
+        if viewValue?
+          valid = isValidIban viewValue
+          if valid
+            parsed = parseIban viewValue
+            if parsed isnt viewValue
+              ctrl.$setViewValue parsed
+              ctrl.$render()
+            parsed
+          else
+            viewValue
+
+      ctrl.$formatters.unshift (modelValue) ->
+        if modelValue?
+          valid = isValidIban modelValue
+          if valid
+            parsed = parseIban modelValue
+            if parsed isnt modelValue
+              scope[attrs.ngModel] = parsed
+            parsed
+          else modelValue
+
       return

--- a/src/ng-iban.coffee
+++ b/src/ng-iban.coffee
@@ -17,25 +17,7 @@ angular
         iban = parseIban(value)
         IBAN.isValid iban
 
-      ctrl.$parsers.unshift (viewValue) ->
-        if viewValue?
-          valid = isValidIban viewValue
-          ctrl.$setValidity 'iban', valid
-          if valid
-            parsed = parseIban viewValue
-            if parsed isnt viewValue
-              ctrl.$setViewValue parsed
-              ctrl.$render()
-            parsed
-          else undefined
+      ctrl.$validators.ngIban = (modelValue) ->
+        isValidIban modelValue
 
-      ctrl.$formatters.unshift (modelValue) ->
-        if modelValue?
-          valid = isValidIban modelValue
-          ctrl.$setValidity 'iban', valid
-          if valid
-            parsed = parseIban modelValue
-            if parsed isnt modelValue
-              scope[attrs.ngModel] = parsed
-            parsed
-          else modelValue
+      return


### PR DESCRIPTION
I have a case where i need to loop through all $validators and set them to valid manually. I have to do this when the input fields are disabled and should therefore not be validated.

My problem is, ng-iban does not use $validators but $parsers/$formatters and sets the validity manually with $setValidity. In this case, the ng-iban validator is not registered in the $validators pipeline.

It would be nice if ng-iban would use the $validtors pipeline.
Please see http://blog.thoughtram.io/angularjs/2015/01/11/exploring-angular-1.3-validators-pipeline.html

Thank you.