### PR TITLE
Use isolated scope for directive

### DIFF
--- a/src/ng-iban.coffee
+++ b/src/ng-iban.coffee
@@ -7,6 +7,8 @@ angular
   .directive 'ngIban', ->
     restrict: 'A'
     require: 'ngModel'
+    scope:
+      ngModel: '='
     link: (scope, elem, attrs, ctrl) ->
       parseIban = (value) ->
         if value? then value.toUpperCase().replace /\s/g, '' else undefined
@@ -38,7 +40,7 @@ angular
           if valid
             parsed = parseIban modelValue
             if parsed isnt modelValue
-              scope[attrs.ngModel] = parsed
+              scope.ngModel = parsed
             parsed
           else modelValue
 


### PR DESCRIPTION
If you're using this directive inside a controller with controllerAs-Syntax scope[attrs.ngModel] would be undefined. Therefore ngModel is now bidirectionally bound to an isolated scope.