### PR TITLE
Set $viewValue to human-friendly representation

### DIFF
--- a/src/ng-iban.coffee
+++ b/src/ng-iban.coffee
@@ -7,6 +7,8 @@ angular
   .directive 'ngIban', ->
     restrict: 'A'
     require: 'ngModel'
+    scope:
+      ngModel: '='
     link: (scope, elem, attrs, ctrl) ->
       parseIban = (value) ->
         if value? then value.toUpperCase().replace /\s/g, '' else undefined
@@ -38,7 +40,7 @@ angular
           if valid
             parsed = parseIban modelValue
             if parsed isnt modelValue
-              scope[attrs.ngModel] = parsed
+              scope.ngModel = parsed
             parsed
           else modelValue
 

--- a/src/ng-iban.coffee
+++ b/src/ng-iban.coffee
@@ -26,9 +26,10 @@ angular
         if viewValue?
           valid = isValidIban viewValue
           if valid
-            parsed = parseIban viewValue
-            if parsed isnt viewValue
-              ctrl.$setViewValue parsed
+            parsed = parseIban viewValue # This becomes the $modelValue
+            pretty = IBAN.printFormat parsed # This the $viewValue
+            if pretty isnt viewValue
+              ctrl.$setViewValue pretty
               ctrl.$render()
             parsed
           else
@@ -38,10 +39,10 @@ angular
         if modelValue?
           valid = isValidIban modelValue
           if valid
-            parsed = parseIban modelValue
+            parsed = parseIban modelValue # This becomes the $modelValue
             if parsed isnt modelValue
               scope.ngModel = parsed
-            parsed
+            pretty = IBAN.printFormat parsed # This the $viewValue
           else modelValue
 
       return

--- a/test/spec/ng-iban-directive.coffee
+++ b/test/spec/ng-iban-directive.coffee
@@ -24,64 +24,75 @@ describe 'Directive: iban', ->
     form.optional.$setViewValue undefined
     scope.$digest()
     expect(scope.optional).toEqual undefined
+    expect(form.optional.$viewValue).toEqual undefined
     expect(form.optional.$valid).toBe true
 
   it 'optional should pass with empty ("") IBAN', ->
     form.optional.$setViewValue ""
     scope.$digest()
     expect(scope.optional).toEqual ""
+    expect(form.optional.$viewValue).toEqual ""
     expect(form.optional.$valid).toBe true
 
   it 'optional should pass with valid IBAN', ->
-    form.optional.$setViewValue 'NL91 ABNA 0417 1643 00'
+    form.optional.$setViewValue 'NL 91AB NA04 1716 4300'
     scope.$digest()
     expect(scope.optional).toEqual 'NL91ABNA0417164300'
+    expect(form.optional.$viewValue).toEqual 'NL91 ABNA 0417 1643 00'
     expect(form.optional.$valid).toBe true
 
   it 'optional should fail with invalid IBAN', ->
-    form.optional.$setViewValue 'NL90 ABNA 0417 1643 00'
+    form.optional.$setViewValue 'NL 90AB NA04 1716 4300'
     scope.$digest()
     expect(scope.optional).toEqual undefined
+    expect(form.optional.$viewValue).toEqual 'NL 90AB NA04 1716 4300'
     expect(form.optional.$valid).toBe false
 
   it 'required should fail with empty IBAN', ->
     form.iban.$setViewValue ''
     scope.$digest()
     expect(scope.iban).toEqual undefined
+    expect(form.iban.$viewValue).toEqual ""
     expect(form.iban.$valid).toBe false
 
   it 'required should pass with valid IBAN', ->
-    form.iban.$setViewValue 'NL91 ABNA 0417 1643 00'
+    form.iban.$setViewValue 'NL 91AB NA04 1716 4300'
     scope.$digest()
     expect(scope.iban).toEqual 'NL91ABNA0417164300'
+    expect(form.iban.$viewValue).toEqual 'NL91 ABNA 0417 1643 00'
     expect(form.iban.$valid).toBe true
 
   it 'required should fail with invalid IBAN', ->
-    form.iban.$setViewValue 'NL90 ABNA 0417 1643 00'
+    form.iban.$setViewValue 'NL 90AB NA04 1716 4300'
     scope.$digest()
     expect(scope.iban).toEqual undefined
+    expect(form.iban.$viewValue).toEqual 'NL 90AB NA04 1716 4300'
     expect(form.iban.$valid).toBe false
 
   it 'country should pass with valid IBAN', ->
-    form.country.$setViewValue 'NL91 ABNA 0417 1643 00'
+    form.country.$setViewValue 'NL 91AB NA04 1716 4300'
     scope.$digest()
     expect(scope.country).toEqual 'NL91ABNA0417164300'
+    expect(form.country.$viewValue).toEqual 'NL91 ABNA 0417 1643 00'
     expect(form.country.$valid).toBe true
 
   it 'country should fail with invalid IBAN', ->
-    form.country.$setViewValue 'NL90 ABNA 0417 1643 00'
+    form.country.$setViewValue 'NL 90AB NA04 1716 4300'
     scope.$digest()
     expect(scope.country).toEqual undefined
+    expect(form.country.$viewValue).toEqual 'NL 90AB NA04 1716 4300'
     expect(form.country.$valid).toBe false
 
   it 'model updates to valid IBAN', ->
-    scope.iban = 'NL91 ABNA 0417 1643 00'
+    scope.iban = 'NL 91AB NA04 1716 4300'
     scope.$digest()
     expect(scope.iban).toEqual 'NL91ABNA0417164300'
+    expect(form.iban.$viewValue).toEqual 'NL91 ABNA 0417 1643 00'
     expect(form.iban.$valid).toBe true
 
   it 'model updates to invalid IBAN', ->
-    scope.iban = 'NL90 ABNA 0417 1643 00'
+    scope.iban = 'NL 90AB NA04 1716 4300'
     scope.$digest()
-    expect(scope.iban).toEqual 'NL90 ABNA 0417 1643 00'
+    expect(scope.iban).toEqual 'NL 90AB NA04 1716 4300'
+    expect(form.iban.$viewValue).toEqual 'NL 90AB NA04 1716 4300'
     expect(form.iban.$valid).toBe false


### PR DESCRIPTION
Once a valid IBAN is entered the input value changes to the human-friendly representation (separated by spaces). But only the `$viewValue` of the ngModel-Controller is changed. The `$modelValue` you use in your code stays an IBAN without spaces.

```html
{{ useriban }}  <!-- NL91ABNA0417164300 -->
{{ useriban | iban }}  <!-- NL91 ABNA 0417 1643 00 -->
<input type="text" ng-model="useriban">  <!-- NL91 ABNA 0417 1643 00 -->
```